### PR TITLE
Fixed issue with Let's Encrypt certificate for Load Balancer in autoscaling deployment

### DIFF
--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -46,15 +46,15 @@ module "red5pro_autoscaling" {
   terraform_service_parallelism     = 10
 
   # Load Balancer HTTPS/SSL certificate configuration
-  https_oci_certificates_use_existing     = false                                     # If you want to use SSL certificate set it to true
-  https_oci_certificates_certificate_name = "red5pro.example.com"                     # Domain name for your SSL certificate
-  cert_private_key                        = "/PATH/TO/EXISTING/SSL/CERTS/privkey.pem" # Path to existing SSL certificate private key
-  cert_public_cert                        = "/PATH/TO/EXISTING/SSL/CERTS/cert.pem"    # Path to existing SSL certificate public key
-
+  lb_https_certificate_create             = false                                       # If you want to use Load Balancer with HTTPS/SSL certificate set it to true
+  lb_https_certificate_name               = "red5pro.example.com"                       # Domain name for your SSL certificate
+  lb_https_certificate_public_cert        = "/PATH/TO/EXISTING/SSL/CERTS/cert.pem"      # Path to SSL certificate public cert
+  lb_https_certificate_fullchain          = "/PATH/TO/EXISTING/SSL/CERTS/fullchain.pem" # Path to SSL certificate fullchain (OPTIONAL)
+  lb_https_certificate_private_key        = "/PATH/TO/EXISTING/SSL/CERTS/privkey.pem"   # Path to SSL certificate private key
 
   # Stream Manager configuration
   stream_manager_instance_type                  = "VM.Standard.E4.Flex" # OCI Instance type for Stream Manager
-  stream_manager_instance_ocpu                  = 2                     # OCI Instance OCPU Count for Stream Manager(1 OCPU               = 2 vCPU)
+  stream_manager_instance_ocpu                  = 2                     # OCI Instance OCPU Count for Stream Manager(1 OCPU 2 vCPU)
   stream_manager_instance_memory                = 8                     # OCI Instance Memory size in GB for Stream Manager
   stream_manager_api_key                        = "examplekey"          # API key for Stream Manager
   stream_manager_autoscaling_desired_capacity   = 1                     # Desired capacity for Stream Manager autoscaling group

--- a/main.tf
+++ b/main.tf
@@ -474,7 +474,7 @@ resource "oci_load_balancer_listener" "red5pro_lb_listener_5080" {
 }
 
 resource "oci_load_balancer_listener" "red5pro_lb_listener_443" {
-  count                    = local.autoscaling && var.https_oci_certificates_use_existing ? 1 : 0
+  count                    = local.autoscaling && var.lb_https_certificate_create ? 1 : 0
   load_balancer_id         = oci_load_balancer_load_balancer.red5pro_lb[0].id
   name                     = "https"
   default_backend_set_name = oci_load_balancer_backend_set.red5pro_lb_backend_set[0].name
@@ -482,8 +482,9 @@ resource "oci_load_balancer_listener" "red5pro_lb_listener_443" {
   protocol                 = "HTTP"
 
   ssl_configuration {
-    certificate_name        = var.https_oci_certificates_certificate_name
+    certificate_name        = var.lb_https_certificate_name
     verify_peer_certificate = false
+    cipher_suite_name       = var.lb_https_certificate_cipher_suite_name
     protocols               = ["TLSv1.1", "TLSv1.2"]
     server_order_preference = "ENABLED"
   }
@@ -492,12 +493,12 @@ resource "oci_load_balancer_listener" "red5pro_lb_listener_443" {
 # OCI SSL certificate
 
 resource "oci_load_balancer_certificate" "red5pro_lb_ssl_cert" {
-  count              = local.autoscaling && var.https_oci_certificates_use_existing ? 1 : 0
+  count              = local.autoscaling && var.lb_https_certificate_create ? 1 : 0
   load_balancer_id   = oci_load_balancer_load_balancer.red5pro_lb[0].id
-  #ca_certificate     = file(var.cert_fullchain)
-  certificate_name   = var.https_oci_certificates_certificate_name
-  private_key        = file(var.cert_private_key)
-  public_certificate = file(var.cert_public_cert)
+  certificate_name   = var.lb_https_certificate_name
+  ca_certificate     = var.lb_https_certificate_fullchain != "" ? file(var.lb_https_certificate_fullchain) : null
+  private_key        = file(var.lb_https_certificate_private_key)
+  public_certificate = file(var.lb_https_certificate_public_cert)
 
   lifecycle {
     create_before_destroy = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -64,7 +64,7 @@ output "load_balancer_http_url" {
 }
 output "load_balancer_https_url" {
   description = "Load Balancer HTTPS URL"
-  value       = local.autoscaling ? var.https_oci_certificates_use_existing ? "https://${var.https_oci_certificates_certificate_name}:443" : null : null
+  value       = local.autoscaling ? var.lb_https_certificate_create ? "https://${var.lb_https_certificate_name}:443" : null : null
 }
 output "single_red5pro_server_ip" {
   description = "Single Red5 Pro Server IP"

--- a/variables.tf
+++ b/variables.tf
@@ -418,23 +418,33 @@ variable "https_letsencrypt_certificate_password" {
   type        = string
   default     = ""
 }
-variable "https_oci_certificates_use_existing" {
+variable "lb_https_certificate_create" {
   description = "Use existing Oracle Cloud Managed certificate (autoscaling)"
   type        = bool
   default     = false
 }
-variable "https_oci_certificates_certificate_name" {
+variable "lb_https_certificate_cipher_suite_name" {
+  description = "The name of the cipher suite to use for HTTPS or SSL connections. RSA use oci-default-ssl-cipher-suite-v1, ECDSA use oci-modern-ssl-cipher-suite-v1 https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingciphersuites_topic-Predefined_Cipher_Suites.htm"
+  type        = string
+  default     = "oci-modern-ssl-cipher-suite-v1"
+}
+variable "lb_https_certificate_name" {
   description = "Oracle Cloud Managed certificate name (autoscaling)"
   type        = string
   default     = ""
 }
-variable "cert_private_key" {
+variable "lb_https_certificate_private_key" {
   description = "File path for SSL/TLS Certificate Private Key (autoscaling)"
   type        = string
   default     = ""
 }
-variable "cert_public_cert" {
+variable "lb_https_certificate_public_cert" {
   description = "File path for SSL/TLS Certificate Public Cert (autoscaling)"
+  type        = string
+  default     = ""
+}
+variable "lb_https_certificate_fullchain" {
+  description = "File path for SSL/TLS Certificate Fullchain (autoscaling)"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
* Add SSL Certificate Fullchain - Optional
* Add ability to choose cipher suite to use for HTTPS or SSL connections, default "oci-modern-ssl-cipher-suite-v1", Let's Encrypt generate ECDSA cert and it works only with this cipher suite. 
* Renamed variables